### PR TITLE
Fixed 'Integration entity not found' error.

### DIFF
--- a/custom_components/aerogarden/manifest.json
+++ b/custom_components/aerogarden/manifest.json
@@ -5,7 +5,6 @@
   "issue_tracker": "https://github.com/jacobdonenfeld/homeassistant-aerogarden/issues",
   "dependencies": [
     "device_tracker",
-    "entity",
     "binary_sensor",
     "light"
   ],


### PR DESCRIPTION
**Issue:** 

When attempting to add the `aerogarden` integration in `configuration.yaml` as instructed, the server refuses to restart, returning the error message "Integration error: aerogarden - Integration 'entity' not found."

**Platform:**

Home Assistant Core 2022.6.5
Home Assistant Supervisor 2022.05.3
Home Assistant OS 8.1

**Repro:** 

1. Install the repository via HACS.
2. Restart, ensuring the repository is visible.
3. Add the username and password under a new `aerogarden` section of `configuration.yaml,` as instructed in the README.
4. Attempt to restart the server to apply the changes.

**Expected behavior:** Reboot is successful, and the sensors for any gardens linked to the indicated account appear.

**Actual behavior:** Reboot is not successful, instead returning the error message "Integration error: aerogarden - Integration 'entity' not found."

**Repeatable:** 5/5

**Potential Fix:** 

Although I'm new to HA/HACS development, it seems that there may not actually be a dependency called `entity`. Removing this from the manifest resolves the issue, allows a reboot, and results in the sensors appearing correctly.